### PR TITLE
chore: create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Documentation for CODEOWNERS:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for all files in the repository, unless overridden by a specific rule below.
+* @jaekwon
+
+# Specific file/dir ownership
+/README.md @jaekwon
+/CONSTITUTION.md @jaekwon
+/DECENTRALISTS.md @jaekwon
+/COMPENDIUM.md @Pipello
+/.github/ @moul

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,9 @@
 /README.md @jaekwon
 /CONSTITUTION.md @jaekwon
 /DECENTRALISTS.md @jaekwon
-/COMPENDIUM.md @Pipello
-/.github/ @moul
+
+# XXX: Pending Ownership Assignments
+# The CODEOWNERS file will be invalid if it lists users without write permissions to the repository.
+# Once the necessary permissions are granted and protected branches are set up, these lines can be uncommented.
+# /COMPENDIUM.md @Pipello
+# /.github/ @moul

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,5 @@
 # XXX: Pending Ownership Assignments
 # The CODEOWNERS file will be invalid if it lists users without write permissions to the repository.
 # Once the necessary permissions are granted and protected branches are set up, these lines can be uncommented.
-# /COMPENDIUM.md @Pipello
+# /COMPENDIUM.md @salmad3
 # /.github/ @moul


### PR DESCRIPTION
Addresses https://github.com/atomone-hub/genesis/issues/23#issuecomment-1837275410.

The file is ready to merge. It sets @jaekwon as the reviewer for main files. Other settings (for secondary files) are commented out to keep the CODEOWNERS file valid. We need write access for those mentioned and proper setup of "Protected Branches" to ensure reviews are required even for those with write access.

@jaekwon, you have two options:
1. Give write access to the @atomone-hub/mod team, add @salmad3 to the team, and set up protected branches. This way, the project stays secure. You'll control merges for main files, and CODEOWNERS can sometimes merge their files.
2. Merge this file as a start. You'll handle all merges, including secondary files, and we'll revisit this later.
