### PR TITLE
chore: format AiB blogpost plus other fixes

### DIFF
--- a/STAKING_VS_MONEY.md
+++ b/STAKING_VS_MONEY.md
@@ -57,8 +57,9 @@ these tokens outright.
 
 $ATOM's primary utility is – and has always been – staking. $ATOM was never
 designed to be a monetary token but a staking token enabling an IBC hub that
-requires the highest level of security (see original token model paper). The
-original design of $ATOM's dynamic inflation, acting as a penalty to
+requires the highest level of security (see [original token model
+paper](https://github.com/cosmos/cosmos/blob/0141bbcdbf68a784348ba059096f8238c696f9a8/Cosmos_Token_Model.pdf)).
+The original design of $ATOM's dynamic inflation, acting as a penalty to
 non-stakers, plays a crucial role in incentivizing network participation and
 security by intentionally limiting the amount of liquid trading $ATOMs so as to
 make hostile takeovers prohibitively expensive. Prop 848 risks undermining
@@ -269,7 +270,7 @@ intended. Any change to this model would make the $ATOM token too tempting to
 be marketed as a monetary token.
 
 What we would like to do instead is to open up a discussion for adjusting the
-NextInflationRate function to become more responsive to reaching the target
+`NextInflationRate` function to become more responsive to reaching the target
 ratio. Let’s find the best way of doing this together and discuss the pros and
 cons openly. Balancing market competitiveness with fundamental aspects of
 network security and economic stability is essential for the continued growth

--- a/STAKING_VS_MONEY.md
+++ b/STAKING_VS_MONEY.md
@@ -1,104 +1,339 @@
-_Originally published Nov 21st, 2023 by All in Bits, Inc; Christina Comben, Adriana Mihai, Giuseppe Natale, Jae Kwon, Valeh Tehranchi_
+_Originally published Nov 21st, 2023 by All in Bits, Inc; Christina Comben,
+Adriana Mihai, Giuseppe Natale, Jae Kwon, Valeh Tehranchi_
 
-# NWV to Prop 848 – $ATOM Must NOT be Money.
+# NWV to Prop 848 – $ATOM Must NOT be Money
 
-AiB will soon be voting NWV to prop 848, $ATOM “Halving,” which aims at turning the $ATOM token into a monetary token rather than a staking token. We value Cosmos' core components of security, sustainability, and decentralization, and cannot support a proposal that may threaten its foundational pillars. Halving $ATOM max inflation at this time with insufficient research and discussion will lead to more undesirable outcomes, namely lowering the bonded ratio of staked $ATOMs significantly, hampering the growth of IBC and ICS adoption, affecting the rewards for validators, and placing the entire Cosmos network at risk. 
+AiB will soon be voting NWV to prop 848, $ATOM “Halving,” which aims at turning
+the $ATOM token into a monetary token rather than a staking token. We value
+Cosmos' core components of security, sustainability, and decentralization, and
+cannot support a proposal that may threaten its foundational pillars. Halving
+$ATOM max inflation at this time with insufficient research and discussion will
+lead to more undesirable outcomes, namely lowering the bonded ratio of staked
+$ATOMs significantly, hampering the growth of IBC and ICS adoption, affecting
+the rewards for validators, and placing the entire Cosmos network at risk.
 
-Prop 848 represents a significant shift from the established tokenomics of the Cosmos Hub that has kept our ecosystem secure and dependable since inception. While prop 848 argues that it would enhance the $ATOM Economic Zone (AEZ) and increase $ATOM's competitiveness in the DeFi space, we disagree categorically and raise the following substantial concerns:
+Prop 848 represents a significant shift from the established tokenomics of the
+Cosmos Hub that has kept our ecosystem secure and dependable since inception.
+While prop 848 argues that it would enhance the $ATOM Economic Zone (AEZ) and
+increase $ATOM's competitiveness in the DeFi space, we disagree categorically
+and raise the following substantial concerns:
 
 ## Destabilizing the Security Model
 
-An IBC hub must not be secured by a monetary token. Securing the chain with a monetary token might make sense for non-hubs that don’t rely on the security of its IBC token pegs (for example, if the chain is only concerned about itself). But this isn’t true by definition in the Cosmos of IBC interconnected chains. A good money token is widely distributed by definition, and therefore less by proportion to the whole would be staked to validators. This leaves the governance of the chain open to be taken-over by anyone who has enough of these monetary tokens, and the increase in the liquidity of this token practically guarantees the success of any adversary with sufficient capital. When the competition is the status quo banking system, there is ample capital to be used against the underdog.
+An IBC hub must not be secured by a monetary token. Securing the chain with a
+monetary token might make sense for non-hubs that don’t rely on the security of
+its IBC token pegs (for example, if the chain is only concerned about itself).
+But this isn’t true by definition in the Cosmos of IBC interconnected chains. A
+good money token is widely distributed by definition, and therefore less by
+proportion to the whole would be staked to validators. This leaves the
+governance of the chain open to be taken-over by anyone who has enough of these
+monetary tokens, and the increase in the liquidity of this token practically
+guarantees the success of any adversary with sufficient capital. When the
+competition is the status quo banking system, there is ample capital to be used
+against the underdog.
 
-In contrast, a staking token that maintains that the supermajority (say ⅔) stays staked has less in circulation as liquid tokens, so the adversary is not guaranteed to be able to purchase enough on the market to succeed in taking over control; while in some cases it may be possible, it is also true that in the scenario with $ATOM as money, the adversary is practically guaranteed success of takeover given reasonable assumptions. It doesn’t make sense in the long run to change what could be secure against the most powerful of adversaries, to one that is guaranteed to fail. And if the reader doesn’t agree that the model should be resilient against the most powerful of adversaries, it means the reader is not aware of history.
+In contrast, a staking token that maintains that the supermajority (say ⅔)
+stays staked has less in circulation as liquid tokens, so the adversary is not
+guaranteed to be able to purchase enough on the market to succeed in taking
+over control; while in some cases it may be possible, it is also true that in
+the scenario with $ATOM as money, the adversary is practically guaranteed
+success of takeover given reasonable assumptions. It doesn’t make sense in the
+long run to change what could be secure against the most powerful of
+adversaries, to one that is guaranteed to fail. And if the reader doesn’t agree
+that the model should be resilient against the most powerful of adversaries, it
+means the reader is not aware of history.
 
-Should proposal 848 pass, it starts a precedent of sliding down the slippery slope of degen behavior, encouraging more yield degens to decrease the inflation even further, and in general, the composition and intelligence of the $ATOM token will decrease to such an extent that it will make harmful and dangerous decisions; because the token holders are not experts in tokenomics as they ought to be, and instead only care for short-term yield. This is made worse by the fact that the Gaia Cosmos Hub is an IBC token-pegging hub, and so there will be real incentives for malicious parties to dupe the unsuspecting voters into approving something that is detrimental to the Hub, its users, and Cosmos at large, or for the malicious parties to use its voting power to steal these tokens outright.
+Should proposal 848 pass, it starts a precedent of sliding down the slippery
+slope of degen behavior, encouraging more yield degens to decrease the
+inflation even further, and in general, the composition and intelligence of the
+$ATOM token will decrease to such an extent that it will make harmful and
+dangerous decisions; because the token holders are not experts in tokenomics as
+they ought to be, and instead only care for short-term yield. This is made
+worse by the fact that the Gaia Cosmos Hub is an IBC token-pegging hub, and so
+there will be real incentives for malicious parties to dupe the unsuspecting
+voters into approving something that is detrimental to the Hub, its users, and
+Cosmos at large, or for the malicious parties to use its voting power to steal
+these tokens outright.
 
-$ATOM's primary utility is – and has always been – staking. $ATOM was never designed to be a monetary token but a staking token enabling an IBC hub that requires the highest level of security (see original token model paper). The original design of $ATOM's dynamic inflation, acting as a penalty to non-stakers, plays a crucial role in incentivizing network participation and security by intentionally limiting the amount of liquid trading $ATOMs so as to make hostile takeovers prohibitively expensive. Prop 848 risks undermining these foundational principles and destabilizing the network's security model.
+$ATOM's primary utility is – and has always been – staking. $ATOM was never
+designed to be a monetary token but a staking token enabling an IBC hub that
+requires the highest level of security (see original token model paper). The
+original design of $ATOM's dynamic inflation, acting as a penalty to
+non-stakers, plays a crucial role in incentivizing network participation and
+security by intentionally limiting the amount of liquid trading $ATOMs so as to
+make hostile takeovers prohibitively expensive. Prop 848 risks undermining
+these foundational principles and destabilizing the network's security model.
 
 ## Phantom Revenue and Flawed Arguments
 
-We should not be passing proposals that are based on faulty premises. The way the proponents of prop 848 have been calculating the cost of security, as well as, in general, how the community is calculating staking income or revenue, is fundamentally flawed because $ATOM is a staking token with ⅔ staked. What we need now is to address this problem by better explaining the better mental model to everyone, and by getting the needed clarification from tax authorities. Please note that nothing here is tax advice, and you should talk to your own tax advisors.
+We should not be passing proposals that are based on faulty premises. The way
+the proponents of prop 848 have been calculating the cost of security, as well
+as, in general, how the community is calculating staking income or revenue, is
+fundamentally flawed because $ATOM is a staking token with ⅔ staked. What we
+need now is to address this problem by better explaining the better mental
+model to everyone, and by getting the needed clarification from tax
+authorities. Please note that nothing here is tax advice, and you should talk
+to your own tax advisors.
 
-When the annual compounded inflation rate of $ATOM is 20%, and because there are generally ⅔ of the $ATOM staked, when you stake your $ATOMs, you earn a 30% return from the original stake, annually. What most people do here is assume that the 30% increase in token supply multiplied by the price of the $ATOM token is all revenue, but we believe this is the wrong way to calculate net revenue for the $ATOM staking token. While the total number of $ATOMs you hold at the end of the year is 1.3x in quantity, the reality is that each $ATOM also went down in proportional utility and value due to the substantial inflation of 20%. What matters is not the number of $ATOMs one holds, but the fraction they hold in comparison to the whole. The effective income considering inflation is actually 1.3x / 1.2x, which equals 8.33%. That is a massive factor of 3.6 to 1. 
+When the annual compounded inflation rate of $ATOM is 20%, and because there
+are generally ⅔ of the $ATOM staked, when you stake your $ATOMs, you earn a 30%
+return from the original stake, annually. What most people do here is assume
+that the 30% increase in token supply multiplied by the price of the $ATOM
+token is all revenue, but we believe this is the wrong way to calculate net
+revenue for the $ATOM staking token. While the total number of $ATOMs you hold
+at the end of the year is 1.3x in quantity, the reality is that each $ATOM also
+went down in proportional utility and value due to the substantial inflation of
+20%. What matters is not the number of $ATOMs one holds, but the fraction they
+hold in comparison to the whole. The effective income considering inflation is
+actually 1.3x / 1.2x, which equals 8.33%. That is a massive factor of 3.6 to 1.
 
-As a thought exercise, if we were to double the amount of $ATOM tokens every address has, and keep the bonding ratio the same, the price of $ATOM would immediately decrease by 50% (but the net value of our holdings would not change); and usually this shouldn’t be seen as a taxable event, and it isn’t in the case of a stock-split.
+As a thought exercise, if we were to double the amount of $ATOM tokens every
+address has, and keep the bonding ratio the same, the price of $ATOM would
+immediately decrease by 50% (but the net value of our holdings would not
+change); and usually this shouldn’t be seen as a taxable event, and it isn’t in
+the case of a stock-split.
 
-As another thought exercise, consider the definition of $MASS = $ATOM / sum($ATOM), where sum($MASS) equals say 1. This unit of measure better represents the intrinsic value of the $ATOM token as a fraction of the whole. With this unit of measure, the calculated income would actually be 8.33% (as opposed to 30% in our example).
+As another thought exercise, consider the definition of $MASS = $ATOM /
+sum($ATOM), where sum($MASS) equals say 1. This unit of measure better
+represents the intrinsic value of the $ATOM token as a fraction of the whole.
+With this unit of measure, the calculated income would actually be 8.33% (as
+opposed to 30% in our example).
 
-Besides the naive model and the $MASS model, the third model says that we should be burning non-staker tokens and claim that the stakers have zero income. This is also reasonable – just because one’s relative ownership in fractions has gone up doesn’t mean that it should be treated as income, since the primary purpose is to disincentivize unbonded tokens and is a form of punishment to a minority subset (of ⅓ more or less). Of course, you can flip this argument around and say that it’s still an incentive for staking (it can be seen as both), so here is a clarifying example; if the $ATOM distribution were like money and massively distributed, and if say only 1% of the $ATOMs were staked, then the inflation going to the stakers is more clearly income.
+Besides the naive model and the $MASS model, the third model says that we
+should be burning non-staker tokens and claim that the stakers have zero
+income. This is also reasonable – just because one’s relative ownership in
+fractions has gone up doesn’t mean that it should be treated as income, since
+the primary purpose is to disincentivize unbonded tokens and is a form of
+punishment to a minority subset (of ⅓ more or less). Of course, you can flip
+this argument around and say that it’s still an incentive for staking (it can
+be seen as both), so here is a clarifying example; if the $ATOM distribution
+were like money and massively distributed, and if say only 1% of the $ATOMs
+were staked, then the inflation going to the stakers is more clearly income.
 
-In comparison, if 99% of the $ATOMs were staked, even with the ludicrous inflation rate of 1,000,000% (for the sake of argument) the inflation shouldn’t be seen as income since the overall distribution by ratio hasn’t changed much at the end of the day; naturally, we perceive this more as a penalty for the 1% that got inflated away. The difference is that the former changes the distribution much more than the latter (generally, the 1% is not like the 100%), and since it depends on a continuous variable (the inflation rate), it is clear that a token can be on a spectrum. Yet it is also correct to say that $ATOM’s original tokenomics makes it primarily a penalty rather than an incentive.
+In comparison, if 99% of the $ATOMs were staked, even with the ludicrous
+inflation rate of 1,000,000% (for the sake of argument) the inflation shouldn’t
+be seen as income since the overall distribution by ratio hasn’t changed much
+at the end of the day; naturally, we perceive this more as a penalty for the 1%
+that got inflated away. The difference is that the former changes the
+distribution much more than the latter (generally, the 1% is not like the
+100%), and since it depends on a continuous variable (the inflation rate), it
+is clear that a token can be on a spectrum. Yet it is also correct to say that
+$ATOM’s original tokenomics makes it primarily a penalty rather than an
+incentive.
 
-This is not tax advice, but we will approach the relevant tax authorities to get better clarity and argue for this model. Of all the options at our disposal, continuing to calculate revenue/income the naive way is the least favorable, irrational option because it is unnecessarily self-sabotaging.
+This is not tax advice, but we will approach the relevant tax authorities to
+get better clarity and argue for this model. Of all the options at our
+disposal, continuing to calculate revenue/income the naive way is the least
+favorable, irrational option because it is unnecessarily self-sabotaging.
 
-Those voting in favor of #848 and choosing to deviate from the ⅔ staking target (which is what will happen after #848) are further sabotaging themselves and everyone else by destroying the arguments above in favor of more favorable tax treatment. The inflation rewards of a monetary token are less likely to be seen as a penalty for non-staking, but a positive incentive to stake.
+Those voting in favor of #848 and choosing to deviate from the ⅔ staking target
+(which is what will happen after #848) are further sabotaging themselves and
+everyone else by destroying the arguments above in favor of more favorable tax
+treatment. The inflation rewards of a monetary token are less likely to be seen
+as a penalty for non-staking, but a positive incentive to stake.
 
 ## A Bad Precedent
 
-Those who argued in favor of #848 have gone so far as to argue that they are merely gauging the interest of the stakers. This fundamental change to tokenomics that goes counter to security and stability is offered without full disclaimers about the true intended purpose (to make $ATOM a monetary token) and its effects. It is also offered without sufficient planning and guarantees for any sort of consistency, and without the needed disclosures of risks. Indeed we don’t even have a Constitution ratified for the Cosmos Hub yet. Furthermore, to make things worse, this proposal is marketed as a “halvening” which has implications about expected price movements, while what is proposed is nothing at all like the immutable halvening schedule of the Bitcoin chain. 
+Those who argued in favor of #848 have gone so far as to argue that they are
+merely gauging the interest of the stakers. This fundamental change to
+tokenomics that goes counter to security and stability is offered without full
+disclaimers about the true intended purpose (to make $ATOM a monetary token)
+and its effects. It is also offered without sufficient planning and guarantees
+for any sort of consistency, and without the needed disclosures of risks.
+Indeed we don’t even have a Constitution ratified for the Cosmos Hub yet.
+Furthermore, to make things worse, this proposal is marketed as a “halvening”
+which has implications about expected price movements, while what is proposed
+is nothing at all like the immutable halvening schedule of the Bitcoin chain.
 
-## A Further Decline in the Bond Ratio 
+## A Further Decline in the Bond Ratio
 
-As noted in the proposal, the current bond ratio of the Cosmos Hub is slightly below the target, not surpassing the ⅔ threshold. This existing condition raises a significant concern: by halving the max inflation, the proposal effectively arrests the increase in staking reward rate, a mechanism currently in place to disincentivize non-staking and push the bond ratio towards the target.
+As noted in the proposal, the current bond ratio of the Cosmos Hub is slightly
+below the target, not surpassing the ⅔ threshold. This existing condition
+raises a significant concern: by halving the max inflation, the proposal
+effectively arrests the increase in staking reward rate, a mechanism currently
+in place to disincentivize non-staking and push the bond ratio towards the
+target.
 
+The design of the Cosmos network dynamically adjusts the inflation rate to
+encourage staking when the bond ratio is below the desired threshold. This
+mechanism is functioning as intended, gradually increasing the inflation rate
+to incentivize more $ATOM holders to stake their tokens, thereby securing the
+network. And it has worked as intended in the past, as shown in the graph
+below. Yet, it was cited as showing that the mechanism doesn’t work using
+flawed math (however, we concede that the rate of change could be faster). The
+proposed reduction will likely result in a further decline in the bond ratio
+when the mechanism should push the ratio to go higher.
 
-The design of the Cosmos network dynamically adjusts the inflation rate to encourage staking when the bond ratio is below the desired threshold. This mechanism is functioning as intended, gradually increasing the inflation rate to incentivize more $ATOM holders to stake their tokens, thereby securing the network. And it has worked as intended in the past, as shown in the graph below. Yet, it was cited as showing that the mechanism doesn’t work using flawed math (however, we concede that the rate of change could be faster). The proposed reduction will likely result in a further decline in the bond ratio when the mechanism should push the ratio to go higher. 
+![graph of time vs bond ratio on
+Gaia](https://github.com/atomone-hub/genesis/blob/0e65b56e4a0739287f2615ebd2c99d0c1bab4a74/resources/stakingrate.png)
 
-![graph of time vs bond ratio on Gaia](https://github.com/atomone-hub/genesis/blob/0e65b56e4a0739287f2615ebd2c99d0c1bab4a74/resources/stakingrate.png)
+The proposal claims that the high $ATOM inflation rate makes DeFi yields less
+competitive. The proposal states, “However, due to the high inflation rate of
+$ATOM, DeFi yield can hardly compete which slows down user growth and
+adoption.” First and foremost this is a gross misunderstanding of the real
+yield from inflation, which as mentioned before, is with the maximum 20%
+compounded annual inflation rate, not at most 30% annual yield, but a net
+8.33%. Secondly, the reasoning is completely flawed because if the yield from
+$ATOM is so high then it should _increase_ user growth and adoption, not
+decrease it. This would be something to celebrate, if true, not stifle.
 
-The proposal claims that the high $ATOM inflation rate makes DeFi yields less competitive. The proposal states, “However, due to the high inflation rate of $ATOM, DeFi yield can hardly compete which slows down user growth and adoption.” First and foremost this is a gross misunderstanding of the real yield from inflation, which as mentioned before, is with the maximum 20% compounded annual inflation rate, not at most 30% annual yield, but a net 8.33%. Secondly, the reasoning is completely flawed because if the yield from $ATOM is so high then it should *increase* user growth and adoption, not decrease it. This would be something to celebrate, if true, not stifle. 
+The higher inflation rate of $ATOM does make it ill-suited for use within DeFi
+applications because $ATOM inflates more in comparison to the yields. But $ATOM
+was never intended to be used this way as money. It makes more sense to use a
+“liquid staking” (a misnomer) service to manage the staking of $ATOM and to use
+the resulting more deflationary liquid staking tokens within DeFi applications,
+but compounding rewards like this also compounds the risk and does not come for
+free.
 
-The higher inflation rate of $ATOM does make it ill-suited for use within DeFi applications because $ATOM inflates more in comparison to the yields. But $ATOM was never intended to be used this way as money. It makes more sense to use a “liquid staking” (a misnomer) service to manage the staking of $ATOM and to use the resulting more deflationary liquid staking tokens within DeFi applications, but compounding rewards like this also compounds the risk and does not come for free. 
+With the support of such stake management services that offer a more
+deflationary derivative token, there must be additional checks against hostile
+takeovers by limiting or throttling how many “liquid staking” tokens can be
+converted back to $ATOMs. Otherwise, there would be little difference in
+security between a monetary $ATOM token and a staking $ATOM token, but the
+distinction between the staking token and the more liquid deflationary token is
+the basis for introducing control measures with different tradeoffs. Otherwise,
+we are left with crude levers to manage this key security issue, such as the %
+of stake that can use ICS, which is not exactly what we need to measure.
 
-With the support of such stake management services that offer a more deflationary derivative token, there must be additional checks against hostile takeovers by limiting or throttling how many “liquid staking” tokens can be converted back to $ATOMs. Otherwise, there would be little difference in security between a monetary $ATOM token and a staking $ATOM token, but the distinction between the staking token and the more liquid deflationary token is the basis for introducing control measures with different tradeoffs. Otherwise, we are left with crude levers to manage this key security issue, such as the % of stake that can use ICS, which is not exactly what we need to measure.
+## IBC Pegged Tokens
 
-IBC Pegged Tokens
+The real risk in security here is not with ICS AEZ economics because what is
+within the AEZ is secured by the same validator set with ICS, and the chain can
+agree to roll back any transactions that are deemed as leading to theft (e.g.
+through an exploit). The real risk lies with pegged IBC tokens on the Cosmos
+Hub. The tokens that are controlled by the Hub but originate from other chains
+external to the Hub and AEZ are all at risk of being stolen.
 
-The real risk in security here is not with ICS AEZ economics because what is within the AEZ is secured by the same validator set with ICS, and the chain can agree to roll back any transactions that are deemed as leading to theft (e.g. through an exploit). The real risk lies with pegged IBC tokens on the Cosmos Hub. The tokens that are controlled by the Hub but originate from other chains external to the Hub and AEZ are all at risk of being stolen. 
-
-All these tokens by default create a real incentive for a malicious actor to exploit. This might be tolerable if the total amount of IBC pegged tokens never exceeded the value of (hypothetically monetary) $ATOM tokens staked divided by 3 (since only ⅓ is guaranteed to be slashable for double-spend attacks with a network partition) but we can’t assume that the Hub will even enforce this invariant when its voters cannot understand the risks of converting $ATOM into a monetary token. Furthermore, most tokens may not be liquid, and re-compensation may not be sufficient recourse for the victims. 
+All these tokens by default create a real incentive for a malicious actor to
+exploit. This might be tolerable if the total amount of IBC pegged tokens never
+exceeded the value of (hypothetically monetary) $ATOM tokens staked divided by
+3 (since only ⅓ is guaranteed to be slashable for double-spend attacks with a
+network partition) but we can’t assume that the Hub will even enforce this
+invariant when its voters cannot understand the risks of converting $ATOM into
+a monetary token. Furthermore, most tokens may not be liquid, and
+re-compensation may not be sufficient recourse for the victims.
 
 ## Beating the Dead Horse of Validator Incentives
 
-Validator incentives are broken in the Cosmos Hub today. Every validator should be roughly equally incentivized to secure each ICS chain in the AEZ, because the work that every validator should be performing to secure each ICS chain is roughly the same. The current incentive model of rewarding validators in proportion to their stake (multiplied by their set commission) is flawed in this regard because nothing guarantees that tail validators will receive the income they need to remain competitive vs top validators, and this is made worse with ICS scaling. With enough scale, all tail validators will necessarily become insolvent and fail, while the ones that are struggling to stay afloat and survive will necessarily need to make business decisions that affect the security of that validator. This is not only suboptimal but cruel.
+Validator incentives are broken in the Cosmos Hub today. Every validator should
+be roughly equally incentivized to secure each ICS chain in the AEZ, because
+the work that every validator should be performing to secure each ICS chain is
+roughly the same. The current incentive model of rewarding validators in
+proportion to their stake (multiplied by their set commission) is flawed in
+this regard because nothing guarantees that tail validators will receive the
+income they need to remain competitive vs top validators, and this is made
+worse with ICS scaling. With enough scale, all tail validators will necessarily
+become insolvent and fail, while the ones that are struggling to stay afloat
+and survive will necessarily need to make business decisions that affect the
+security of that validator. This is not only suboptimal but cruel.
 
-The proposed change disproportionately affects smaller validators. While this will cease to be a problem once validator incentives are fixed to be more equal, it still remains a problem until the overall validator incentive model is fixed, and therefore presents an unnecessary risk to smaller validators. One analysis showed that over 74% of Cosmos Hub validators risk becoming unprofitable with less than six consumer chains. Reducing the max inflation can only exacerbate this problem, and make all these validators unprofitable sooner. We should never tolerate the risk of mass validator failures leading to centralization.
+The proposed change disproportionately affects smaller validators. While this
+will cease to be a problem once validator incentives are fixed to be more
+equal, it still remains a problem until the overall validator incentive model
+is fixed, and therefore presents an unnecessary risk to smaller validators. One
+analysis showed that over 74% of Cosmos Hub validators risk becoming
+unprofitable with less than six consumer chains. Reducing the max inflation can
+only exacerbate this problem, and make all these validators unprofitable
+sooner. We should never tolerate the risk of mass validator failures leading to
+centralization.
 
 ## The Min Inflation Rate shouldn’t change either
 
-While it is true that with the ICS-enabled transaction scaling, the rewards from transaction fees can and will drive the inflation rate to zero and even negative if we allow it, this is not good if it leads to the promotion and adoption of the $ATOM token as a monetary token (and it will). For this reason, we do not suggest removing the minimum inflation rate bounds of 7% either. This will help retain the intelligence of the $ATOM token distribution and prevent naive token holders from affecting it negatively (and the target demographic of a monetary token is naive because it is the general population).
+While it is true that with the ICS-enabled transaction scaling, the rewards
+from transaction fees can and will drive the inflation rate to zero and even
+negative if we allow it, this is not good if it leads to the promotion and
+adoption of the $ATOM token as a monetary token (and it will). For this reason,
+we do not suggest removing the minimum inflation rate bounds of 7% either. This
+will help retain the intelligence of the $ATOM token distribution and prevent
+naive token holders from affecting it negatively (and the target demographic of
+a monetary token is naive because it is the general population).
 
-The negative consequence of keeping the minimum inflation bound at 7% is that the ratio of bonded tokens may rise above ⅔ and the amount of liquid supply may be too small for an accurate measure of the staking token market cap, which can negatively impact the quantifiable security offered by the Hub. However, this effect is limited because when the rewards from ICS transaction throughputs are high (presumably why the bonding rate is high), then there are other ways to calculate the value of the Hub through its continuous revenue, as long as the fees are primarily paid in other tokens besides the $ATOM token.
+The negative consequence of keeping the minimum inflation bound at 7% is that
+the ratio of bonded tokens may rise above ⅔ and the amount of liquid supply may
+be too small for an accurate measure of the staking token market cap, which can
+negatively impact the quantifiable security offered by the Hub. However, this
+effect is limited because when the rewards from ICS transaction throughputs are
+high (presumably why the bonding rate is high), then there are other ways to
+calculate the value of the Hub through its continuous revenue, as long as the
+fees are primarily paid in other tokens besides the $ATOM token.
 
 ## Where Do We Go From Here?
 
-While we are most staunchly against prop 848 for all the reasons detailed above, there should always be room for experimentation, innovation, and open discussion and debate – as long as we agree to never compromise the network’s security and follow a cautious and measured approach. Given that $ATOM should not be a monetary token, the current design with a minimum inflation rate of 7% and a maximum one of 20% put in place to secure the network is working as intended. Any change to this model would make the $ATOM token too tempting to be marketed as a monetary token. 
+While we are most staunchly against prop 848 for all the reasons detailed
+above, there should always be room for experimentation, innovation, and open
+discussion and debate – as long as we agree to never compromise the network’s
+security and follow a cautious and measured approach. Given that $ATOM should
+not be a monetary token, the current design with a minimum inflation rate of 7%
+and a maximum one of 20% put in place to secure the network is working as
+intended. Any change to this model would make the $ATOM token too tempting to
+be marketed as a monetary token.
 
-What we would like to do instead is to open up a discussion for adjusting the NextInflationRate function to become more responsive to reaching the target ratio. Let’s find the best way of doing this together and discuss the pros and cons openly. Balancing market competitiveness with fundamental aspects of network security and economic stability is essential for the continued growth and success of the Cosmos network.
+What we would like to do instead is to open up a discussion for adjusting the
+NextInflationRate function to become more responsive to reaching the target
+ratio. Let’s find the best way of doing this together and discuss the pros and
+cons openly. Balancing market competitiveness with fundamental aspects of
+network security and economic stability is essential for the continued growth
+and success of the Cosmos network.
 
-From a bird's eye perspective looking at the current results of the proposal so far and the discourse we are seeing from the community, there is a clear lack of leadership in guiding the community toward making the necessary decisions. Since proposition 82 we have been working on proposals to improve the governance of the Cosmos Hub that should be prioritized over proposals such as 848. However, the ICF doesn’t appear to be helping and is often involved in backing bad proposals. While we might win here in defeating 848 after we vote NWV (and we urge everyone to do the same, and change votes to NWV), the overall situation is not amenable to what we need in order to succeed, and without active measures, we see this situation continue to worsen. 
+From a bird's eye perspective looking at the current results of the proposal so
+far and the discourse we are seeing from the community, there is a clear lack
+of leadership in guiding the community toward making the necessary decisions.
+Since proposition 82 we have been working on proposals to improve the
+governance of the Cosmos Hub that should be prioritized over proposals such as
+848. However, the ICF doesn’t appear to be helping and is often involved in
+backing bad proposals. While we might win here in defeating 848 after we vote
+NWV (and we urge everyone to do the same, and change votes to NWV), the overall
+situation is not amenable to what we need in order to succeed, and without
+active measures, we see this situation continue to worsen.
 
-We will soon publish a plan that will improve this situation with the Hub. Please stay tuned for more information.  
+We will soon publish a plan that will improve this situation with the Hub.
+Please stay tuned for more information.  
 
 —----
 
 ## Twitter Thread
 
-1/ Dear Cosmonauts, All in Bits (AiB) will vote NWV on prop 848, ATOM Halving. We value Cosmos' core components of security, sustainability, and decentralization and cannot support a proposal that threatens its foundational pillars.
+1/ Dear Cosmonauts, All in Bits (AiB) will vote NWV on prop 848, ATOM Halving.
+We value Cosmos' core components of security, sustainability, and
+decentralization and cannot support a proposal that threatens its foundational
+pillars.
 
-2/ #848 aims at turning the $ATOM token into a monetary token. But $ATOM's primary utility is – and has always been – a staking token enabling an IBC hub that requires the highest level of security.
+2/ #848 aims at turning the $ATOM token into a monetary token. But $ATOM's
+primary utility is – and has always been – a staking token enabling an IBC hub
+that requires the highest level of security.
 
-3/ “Halving” $ATOM max inflation with insufficient research and discussion will lead to undesirable outcomes, significantly lowering the bonded ratio of staked $ATOMs, hampering the growth of IBC and ICS, affecting rewards for validators, and placing the Cosmos network at risk. 
+3/ “Halving” $ATOM max inflation with insufficient research and discussion will
+lead to undesirable outcomes, significantly lowering the bonded ratio of staked
+$ATOMs, hampering the growth of IBC and ICS, affecting rewards for validators,
+and placing the Cosmos network at risk.
 
-4/ #848 is a significant shift from the established tokenomics of the Cosmos Hub that has kept our ecosystem secure and dependable. Furthermore, the proposal is marketed as a “halvening,” yet is nothing like the immutable halvening schedule of the Bitcoin chain. 
+4/ #848 is a significant shift from the established tokenomics of the Cosmos
+Hub that has kept our ecosystem secure and dependable. Furthermore, the
+proposal is marketed as a “halvening,” yet is nothing like the immutable
+halvening schedule of the Bitcoin chain.
 
-5/ The way the proponents of prop 848 have been calculating the cost of security, as well as, in general, how the community is calculating staking income or revenue, is fundamentally flawed. We should not pass proposals that are based on faulty premises.
+5/ The way the proponents of prop 848 have been calculating the cost of
+security, as well as, in general, how the community is calculating staking
+income or revenue, is fundamentally flawed. We should not pass proposals that
+are based on faulty premises.
 
-6/ #848 disproportionately affects smaller validators. One analysis showed that over 74% of Cosmos Hub validators risk becoming unprofitable with less than 6 consumer chains. We should not discuss reducing the max inflation without fixing the validators incentive problem first. 
+6/ #848 disproportionately affects smaller validators. One analysis showed that
+over 74% of Cosmos Hub validators risk becoming unprofitable with less than 6
+consumer chains. We should not discuss reducing the max inflation without
+fixing the validators incentive problem first.
 
-7/ There is a clear lack of leadership in guiding the community toward making necessary decisions, and we fear this situation will continue to worsen. We are therefore working on a plan to improve this situation that we will be sharing with the community soon.
+7/ There is a clear lack of leadership in guiding the community toward making
+necessary decisions, and we fear this situation will continue to worsen. We are
+therefore working on a plan to improve this situation that we will be sharing
+with the community soon.
 
-8/ A thorough understanding of the presented arguments is vital for informed decision-making, and we invite the community to assess the points raised and actively participate in the discussion. For full details, please read our complete post: https://forum.cosmos.network/t/proposal-set-max-inflation-at-10/11841/240?u=aib
+8/ A thorough understanding of the presented arguments is vital for informed
+decision-making, and we invite the community to assess the points raised and
+actively participate in the discussion. For full details, please read our
+complete post:
+<https://forum.cosmos.network/t/proposal-set-max-inflation-at-10/11841/240?u=aib>
 
-9/ We will hold a Twitter space at 10 pm PDT today (7 am CET Wednesday) to discuss prop #848. If you share our concerns or would like to meaningfully contribute to the discussion, join us and be part of the dialogue. #CosmosDebate #TwitterSpace
+9/ We will hold a Twitter space at 10 pm PDT today (7 am CET Wednesday) to
+discuss prop #848. If you share our concerns or would like to meaningfully
+contribute to the discussion, join us and be part of the dialogue.
+#CosmosDebate #TwitterSpace


### PR DESCRIPTION
- format to enforce 80-char length
- fix `IBC Pegged Tokens` title.
- add missing link to cosmos token model paper