### PR TITLE
chore(compendium): add latest issues

### DIFF
--- a/COMPENDIUM.md
+++ b/COMPENDIUM.md
@@ -53,6 +53,7 @@ Its purpose is multi-fold:
 | [<ins>#74: Improving Delegators and Chain Safety</ins>](https://github.com/atomone-hub/genesis/issues/74)             | stevenoruzi              | Addressing the safety of delegators in the Cosmos ecosystem and proposing solutions for better validator accountability and network security.       |
 | [<ins>#75: Validators and KYC</ins>](https://github.com/atomone-hub/genesis/issues/75)                                | jaekwon                  | Exploring KYC requirements and jurisdiction policies for validators in AtomOne.   
 | [<ins>#81: Liquid Staked ATONE</ins>](https://github.com/atomone-hub/genesis/issues/81)                               | WaqarMMirza          | Proposal to improve liquid staking in the AtomOne ecosystem by introducing multilevel Liquid Staking Tokens (LSTs) with a unified pool and universal recognition. |
+| [<ins>#83: AtomOne GovNo Community Townhalls</ins>](https://github.com/atomone-hub/genesis/issues/83)                | adrianakalpa         | Planning and discussion of community townhalls for the GovNo chain, including agendas, member participation, and development updates.                |
 
 ---
 
@@ -117,7 +118,7 @@ the improvement of governance and community pool design for AtomOne.
 - Discussion on preventing governance misuse for "griefing" and ensuring it represents the will of the common Atom One delegator.
 - Proposals to lock voting rights to addresses staked at the beginning of each proposal and to restrict last-minute vote changes.
 - Mandating public community hearings for new governance proposals and a minimum discussion period on public forums.
-- Exploring better utilization of Atom One delegators/voters in negotiations and proposal iterations.
+- Exploring better utilization of AtomOne delegators/voters in negotiations and proposal iterations.
 - Strategies to minimize spam proposals and standardize community pool-funded operations.
 - Suggestions for alternative validator power structures, including validators voting as per their delegator's majority.
 - Debating voting limitations for "dust accounts" and recalibrating quorum requirements.
@@ -410,8 +411,6 @@ communication alternatives for AtomOne users.
 - Community feedback on various naming options, including '$ATONE'.
 - Discussion on balancing the need for a distinctive identity with avoiding contention and confusion.
 - Various perspectives on how to distinguish AtomOne's branding from existing trademarks.
-- Suggestions for names that reflect the project's identity as a fork and its unique economic security model.
-- Feedback on the use of 'ATONE' as a potential ticker and its reception within the community.
 
 ### Choose the $ATOM1 ticker ($ATONE)
 
@@ -512,7 +511,6 @@ list for AtomOne.
 - The repository could serve as a reference for new forks, important tweets, and other relevant information.
 - Discussion on limiting AI usage to a specific section within the repository and setting boundaries for its use.
 - Support for the idea of starting with an AWESOME.md file and observing how it evolves.
-- Suggestions for maintaining a balance between AI assistance and human curation.
 
 ### How to Attract Aligned Individuals to a New Constitutional Hub
 
@@ -522,12 +520,24 @@ list for AtomOne.
 
 - Focus on drawing in individuals both inside and outside the crypto space who align with AtomOne's vision of prioritizing security and hub minimalism.
 - Addressing societal issues that led to distrust in current institutions as a way to connect with a broader audience.
-- Proposing content creation that highlights problems created by existing systems, targeting a wider audience beyond crypto-natives.
+- Proposing content creation that highlights problems created by existing systems, targeting a wider audience beyond crypto-natives and to encourage participation from non-technical members.
 - Idea of creating a "political economy" within the AtomOne Hub, involving commerce of physical goods to engage the community in a new way.
 - Suggestion to scale voting power in favor of delegators, reducing the influence of validators in governance decisions to enhance the sense of equality in participation.
-- Discussions on how to make the ATOM1 Hub appealing to a wider range of people, particularly those disillusioned with traditional institutions.
-- Considerations of how to structure the ecosystem to encourage participation from non-technical members.
-- Suggestions for integrating commerce and real-world applications into the AtomOne ecosystem to foster a sense of community and participation.
+- Discussions on how to make the AtomOne Hub appealing to a wider range of people, particularly those disillusioned with traditional institutions.
+
+### AtomOne GovNo Community Townhalls
+
+[<ins>Issue #83</ins>](https://github.com/atomone-hub/genesis/issues/83) proposes a structure for community townhalls focused on the GovNo chain.
+
+#### Key points:
+
+- Establishing a regular schedule for community townhalls to discuss GovNo chain developments.
+- Preliminary agenda includes defining the GovNo chain, its governance token, governance structure, and its relationship with AtomOne.
+- Discussion on the role of validators, members, and external contributors in the GovNo ecosystem.
+- Addressing the process of self-organization and autonomy within the GovNo community.
+- Providing updates on the technical development, validator onboarding, and current priorities of the GovNo chain.
+- Planning for future community initiatives, prioritizing community concerns, and setting action items for subsequent meetings.
+- Encouragement for community members to contribute topics or questions for the townhall agenda.
 
 ---
 
@@ -602,8 +612,6 @@ for categorizing issues in AtomOne.
 - Items include defining the constitution, legal and licensing issues, governance and community engagement strategies, technical aspects and innovation, documentation and resources, recovery and compliance, and preparation for mainnet launch.
 - Discussion on maintaining a single source of truth for the roadmap, with a suggestion to keep it in the README for better accessibility.
 - The roadmap includes links to related issues and discussions, such as governance improvements and software targets.
-- Preference for maintaining the roadmap tasks in the README for visibility and ease of access.
-- Suggestions for organizing the roadmap in a tree structure with checkboxes for better tracking and visualization.
 
 ### Internationalization
 
@@ -617,4 +625,3 @@ for categorizing issues in AtomOne.
 - Encouragement for community members to contribute translations to naturally gauge interest and grow the decentralized localized community ecosystem.
 - Community members volunteering to translate documents into Spanish, Persian, Italian, and French, with an emphasis on collaborative efforts.
 - Suggestions for contracting human translators for languages where community volunteers are not available.
-- Discussion on the importance of human translators in conveying ideas accurately and preserving linguistic nuances.

--- a/COMPENDIUM.md
+++ b/COMPENDIUM.md
@@ -23,7 +23,6 @@ Its purpose is multi-fold:
 | [<ins>#17: Choosing the Genesis Software Target</ins>](https://github.com/atomone-hub/genesis/issues/17)             | moul                 | Discussion on starting with Tendermint 2 or forking from Cosmos Hub 4. Trade-offs between early start and required work.                            |
 | [<ins>#18: Choose Snapshot Attributes</ins>](https://github.com/atomone-hub/genesis/issues/18)                       | moul                 | Debate on specific block for snapshot. Consideration of other proposals beyond proposal 848.                                                        |
 | [<ins>#19: Fix Cosmos Ecosystem Power Dynamics</ins>](https://github.com/atomone-hub/genesis/issues/19)              | andergri             | Reducing political complexities and promoting inclusivity in the Cosmos Ecosystem. Proposal of a primary chain to support all teams.                |
-| [<ins>#20: Official Cosmos ATOM-ONE NFT</ins>](https://github.com/atomone-hub/genesis/issues/20)                     | COverS8              | Proposal for an official AtomOne NFT at genesis. Discussion on its potential as a community-building tool.                                         |
 | [<ins>#21: ATOM-ONE Secure Communications for Users</ins>](https://github.com/atomone-hub/genesis/issues/21)         | COverS8              | Need for secure communication alternatives to Telegram and Discord. Proposal for a secure app for official governance communications.               |
 | [<ins>#22: Link with Tendermint Atom One</ins>](https://github.com/atomone-hub/genesis/issues/22)                    | moul                 | Questions about the connection between the AtomOne repository and Tendermint Atom One. Suggestions for a constitution and clarity on PHOTON design. |
 | [<ins>#23: Issues/PRs Moderation</ins>](https://github.com/atomone-hub/genesis/issues/23)                            | moul                 | Challenge of selecting a responsible party for moderation. Proposal of an operations committee for moderation decisions.                            |
@@ -40,6 +39,20 @@ Its purpose is multi-fold:
 | [<ins>#39: Limit AI/ChatGPT from AtomOne Core</ins>](https://github.com/atomone-hub/genesis/issues/39) | jaekwon | Debate on the role and limitations of AI in AtomOne. Discussion on potential risks and benefits of AI integration in blockchain technology. |
 | [<ins>#40: Governance & Community Pool Thoughts</ins>](https://github.com/atomone-hub/genesis/issues/40)             | clockworkgr            | Discussions on improving governance and community pool design in AtomOne. Suggestions include separating staking and governance and overhauling community pool funding. |
 | [<ins>#41: $PHOTON Token Design</ins>](https://github.com/atomone-hub/genesis/issues/41)                             | giunatale             | Delving into the design and functionality of the $PHOTON token. Topics include governance rights, auto-staking mechanisms, and tokenomics.           |
+| [<ins>#44: Fund a Central Support Team for Chains on CosmosOne</ins>](https://github.com/atomone-hub/genesis/issues/44) | tintin2828           | Proposal to fund a central support team for all chains launched on CosmosOne, specifically for routing IBC transactions. Discussing the potential of AtomOne Hub to route transactions and support new chains in its ecosystem. |
+| [<ins>#45: Governance Improvements</ins>](https://github.com/atomone-hub/genesis/issues/45)                           | Ticojohnny           | Discussion on various improvements to the governance system in AtomOne, focusing on representation and efficiency.                                    |
+| [<ins>#50: META - High-Level Roadmap with DAGs</ins>](https://github.com/atomone-hub/genesis/issues/50)               | moul                 | Development of a high-level roadmap using DAGs as a structural framework for the AtomOne project.                                                     |
+| [<ins>#55: FAQ / AMA</ins>](https://github.com/atomone-hub/genesis/issues/55)                                         | moul                 | Creation of an FAQ/AMA forum for addressing community questions and concerns within the AtomOne project.                                               |
+| [<ins>#58: ATOM Trade mark infringement</ins>](https://github.com/atomone-hub/genesis/issues/58)                      | FarOutAndCosmic      | Addressing the concerns of potential trademark infringement with the use of 'ATOM' in the context of Cosmos & blockchain.                              |
+| [<ins>#60: Internationalization</ins>](https://github.com/atomone-hub/genesis/issues/60)                              | jaekwon              | Initiative to translate AtomOne's documents into multiple languages, emphasizing human translation over AI.                                           |
+| [<ins>#63: Choose the $ATOM1 ticker ($ATONE)</ins>](https://github.com/atomone-hub/genesis/issues/63)                 | moul                 | Discussion and selection of the $ATOM1 ticker, with a temporary decision to use $ATONE.                                                               |
+| [<ins>#66: Define ICS1.5</ins>](https://github.com/atomone-hub/genesis/issues/66)                                     | tbruyelle            | Exploring the evolution and definition of Interchain Security (ICS) 1.5 within the AtomOne framework.                                                  |
+| [<ins>#70: Create an awesome-atomone / community repo</ins>](https://github.com/atomone-hub/genesis/issues/70)        | moul                 | Proposal to create a community-driven repository for AtomOne, including discussions, initiatives, recipes, and scripts.                               |
+| [<ins>#71: AtomOne GovNo (💩, governance-only) chain</ins>](https://github.com/atomone-hub/genesis/issues/71)          | jaekwon              | Proposal for a governance-only chain, AtomOne GovNo, focused on sentiment assessment and governance discussion.                                       |
+| [<ins>#72: How to Attract Aligned Individuals to a New Constitutional Hub</ins>](https://github.com/atomone-hub/genesis/issues/72) | floridamanfintech        | Discussion on strategies for attracting individuals aligned with AtomOne's ethos and principles to the new constitutional hub.                       |
+| [<ins>#74: Improving Delegators and Chain Safety</ins>](https://github.com/atomone-hub/genesis/issues/74)             | stevenoruzi              | Addressing the safety of delegators in the Cosmos ecosystem and proposing solutions for better validator accountability and network security.       |
+| [<ins>#75: Validators and KYC</ins>](https://github.com/atomone-hub/genesis/issues/75)                                | jaekwon                  | Exploring KYC requirements and jurisdiction policies for validators in AtomOne.   
+| [<ins>#81: Liquid Staked ATONE</ins>](https://github.com/atomone-hub/genesis/issues/81)                               | WaqarMMirza          | Proposal to improve liquid staking in the AtomOne ecosystem by introducing multilevel Liquid Staking Tokens (LSTs) with a unified pool and universal recognition. |
 
 ---
 
@@ -94,6 +107,40 @@ the improvement of governance and community pool design for AtomOne.
 - Community pool overhaul suggestions, including limits on funding per proposal and denominating
   proposals in fiat equivalent.
 - Gradual release of funds for proposals, with possible rescinding based on future approval.
+
+### Governance Improvements
+
+[<ins>Issue #45</ins>](https://github.com/atomone-hub/genesis/issues/45) addresses the need for improvements in AtomOne's governance system, emphasizing fair representation and efficiency.
+
+#### Key points:
+
+- Discussion on preventing governance misuse for "griefing" and ensuring it represents the will of the common Atom One delegator.
+- Proposals to lock voting rights to addresses staked at the beginning of each proposal and to restrict last-minute vote changes.
+- Mandating public community hearings for new governance proposals and a minimum discussion period on public forums.
+- Exploring better utilization of Atom One delegators/voters in negotiations and proposal iterations.
+- Strategies to minimize spam proposals and standardize community pool-funded operations.
+- Suggestions for alternative validator power structures, including validators voting as per their delegator's majority.
+- Debating voting limitations for "dust accounts" and recalibrating quorum requirements.
+- Discussion on private voting and mission-specific funding organizations for more targeted governance.
+- Concerns about validator influence overpowering individual votes.
+- Ideas on restructuring voting power to better reflect the community's will.
+- Potential systemic challenges with cryptocurrency governance and the need for future-proofing the governance model.
+
+### AtomOne GovNo (💩, governance-only) chain
+
+[<ins>Issue #71</ins>](https://github.com/atomone-hub/genesis/issues/71) proposes the creation of a governance-only chain, AtomOne GovNo, as an independent component of genesis.
+
+#### Key points:
+
+- AtomOne GovNo chain is proposed as a governance-focused chain, using a proposed token GOVNO solely for governance and staking.
+- The chain would be a fork of cosmoshub4 with minimal modifications and SendTx disabled for GOVNO, emphasizing its non-monetary value.
+- The primary purpose is to assess sentiments of No and NoWithVeto voters from proposition #848 and to discuss next steps for AtomOne.
+- The chain would include a high deposit limit for proposals to prevent spamming and a consideration for slashing deposits if a proposal is heavily vetoed.
+- Discussion on using a supermajority (⅔) for governance decisions and having proposals first discussed on GitHub.
+- Consideration of different ways to evolve GOVNO over time, possibly through peer connections, meritocratic means, or standardized testing events.
+- Suggestions to maintain a focus on sentiment assessment and avoid the potential for financial incentivization or misuse.
+- Various community members expressed interest in participating in the process, coding, running validators, and voting.
+- Discussions on the potential long-term evolution of the AtomOne GovNo chain, its naming, and the implications of its governance-only focus.
 
 ---
 
@@ -163,6 +210,20 @@ design and functionality of the $PHOTON token system.
 - Examination of bonding dynamics, including incentives and impacts of slashing events.
 - Need for defining a practical redemption mechanism for PHOTON, considering various dynamics
   of the dual-token model.
+
+### Liquid Staked ATONE
+
+[<ins>Issue #81</ins>](https://github.com/atomone-hub/genesis/issues/81) addresses the concept of liquid staking within the AtomOne ecosystem.
+
+#### Key points:
+
+- Discussion on the current challenges of liquid staking in the Cosmos Hub, particularly in terms of governance voting power and validator selection.
+- Proposal for a multilevel Liquid Staking Tokens (LSTs) system where each validator issues a unique LST, converging into a unified and universally recognized LST (stATONE).
+- This system is intended to preserve the decentralization ethos of AtomOne while offering the benefits of liquid staking.
+- Concerns raised about the potential governance takeover threat posed by liquid staking tokens with governance power.
+- Suggestions to limit validator choices for liquid staking for security reasons and to address the Principal-Agent problem.
+- Emphasis on the need for careful implementation to avoid governance issues.
+- A suggestion to look at existing discussions on liquid staking in AtomOne, particularly in Issue #41 and the genesis README.
 
 ---
 
@@ -250,6 +311,66 @@ security standards into proposal evaluations for AtomOne.
 - Emphasis on balanced decision-making, combining strict security measures with adaptability for urgent
   proposals.
 
+### Fund a Central Support Team for Chains Launching on CosmosOne
+
+[<ins>Issue #44</ins>](https://github.com/atomone-hub/genesis/issues/44) proposes the establishment of a central support team for all chains launching on CosmosOne and the Hub, with a focus on managing IBC transactions.
+
+#### Key points:
+
+- The idea of a central support team to manage IBC transactions for all chains launched on CosmosOne.
+- Potential for significant revenue generation through this initiative, which could be used for ecosystem growth, support, and user rewards.
+- Discussion about AtomOne Hub's role in routing transactions and supporting new chains within its ecosystem.
+- Consideration of AtomOne Hub as an alternative to using external relayers for transaction routing.
+- Exploration of the possibility of AtomOne allowing new chains to launch and create their own ecosystem while connecting via IBC to the current Cosmos network and beyond.
+
+### Define ICS1.5
+
+[<ins>Issue #66</ins>](https://github.com/atomone-hub/genesis/issues/66) discusses the evolution and potential definition of Interchain Security (ICS) 1.5 in the AtomOne context.
+
+#### Key points:
+
+- Discussion about the different versions of main ICS protocols and the specific characteristics of ICS1.5.
+- ICS1.5 as an evolution of Replicated Security, focusing on provider and consumer chain dynamics.
+- Proposal to remove VCSMaturedPackets in ICS1.5 and the security implications of such a change.
+- Consideration of two types of consumer chains in ICS1.5: "core shards" and "consumer shards", with core shards having a stronger link to the provider chain, particularly in governance.
+- The need for further clarification on the differences between core and consumer shards.
+- Potential other features of ICS1.5, including fast inter-hub communication with implied IBC without sacrificing independent BFT consensus layers.
+- Community members provided insights on the complexity and security implications of proposed changes in ICS1.5.
+- Discussions about the feasibility of implementing an "implicit" IBC for faster communication and shared validator sets.
+- Suggestions that consumer and core shards might not require modifications to ICS but rather depend on how the consumer chain is designed.
+
+### Improving Delegators and Chain Safety
+
+[<ins>Issue #74</ins>](https://github.com/atomone-hub/genesis/issues/74) discusses enhancing the safety and fairness for delegators and proposing measures for better validator accountability in the Cosmos ecosystem.
+
+#### Key points:
+
+- Concerns about the impact of validator misconduct on delegators, especially those with minimal self-bonding.
+- Suggestions for a variable minimum self-bond requirement or displaying self-bond amounts to inform delegators.
+- Proposal to disallow the practice of creating new validators with the same name after one is jailed to prevent trust misuse.
+- Idea of imposing a cap on the amount of bonded tokens per validator to prevent centralization and encourage a more diverse validator set.
+- Consideration of automated undelegation processes for jailed validators to enhance staking security and fairness.
+- Discussions on the potential of variable rewards systems to discourage centralization and incentivize validators to maintain a "Goldilocks Zone" for optimal reward earning.
+- Debates on the practicality and fairness of various proposed solutions, such as self-bonding requirements and reward adjustments.
+- Considerations for supporting new or small validators during the genesis phase and creating risk assessment tools for delegators.
+- Discussions on the constitutionality and technical feasibility of implementing proposed measures for validator governance and delegator protection.
+
+### Validators and KYC
+
+[<ins>Issue #75</ins>](https://github.com/atomone-hub/genesis/issues/75) discusses the need for Know Your Customer (KYC) procedures for validators in the AtomOne ecosystem.
+
+#### Key points:
+
+- Importance of KYC to ensure validator accountability and prevent Sybil attacks.
+- Debate on the implementation of jurisdiction policy by validators and its subjectivity.
+- Proposal for validators to self-declare their jurisdiction with a blockchain-based identifier.
+- Discussion on the use of third-party identity verification services to confirm validators' jurisdiction.
+- Suggestions for constitutional requirements for validators to provide accurate information, with potential penalties for misinformation.
+- Consensus on starting with a permissionless base and supporting control experiments while preserving freedoms.
+- Concerns about the subjective implementation of jurisdiction policies and potential biases in validator selection.
+- Emphasis on the reputational stakes for validators in providing accurate jurisdiction information.
+- Discussion on the simplicity and effectiveness of self-declaration and information transparency for delegators.
+
 ---
 
 ## Branding and Public Relations
@@ -276,6 +397,37 @@ communication alternatives for AtomOne users.
 - Need for end-to-end encrypted communication channels.
 - An official, secure app or platform for governance communication is proposed.
 
+### ATOM Trade mark infringement
+
+[<ins>Issue #58</ins>](https://github.com/atomone-hub/genesis/issues/58) raises concerns about the potential trademark infringement involving the use of 'ATOM' in the context of the Cosmos and blockchain ecosystem.
+
+#### Key points:
+
+- Discussion on whether the use of 'ATOM' infringes on trademarks owned by the ICF in the context of Cosmos and blockchain.
+- Debate on the distinction between 'AtomOne' and 'ATOM', and whether a rebranding might be necessary.
+- Considerations about AtomOne's identity as a fork and how it should be reflected in its branding.
+- Suggestions for different names and tickers, including 'Cosmos Hub Classic', 'Cosmos Classic', and '$GAIA', although some proposed tickers are already in use.
+- Community feedback on various naming options, including '$ATONE'.
+- Discussion on balancing the need for a distinctive identity with avoiding contention and confusion.
+- Various perspectives on how to distinguish AtomOne's branding from existing trademarks.
+- Suggestions for names that reflect the project's identity as a fork and its unique economic security model.
+- Feedback on the use of 'ATONE' as a potential ticker and its reception within the community.
+
+### Choose the $ATOM1 ticker ($ATONE)
+
+[<ins>Issue #63</ins>](https://github.com/atomone-hub/genesis/issues/63) focuses on choosing a suitable ticker for AtomOne, with an interim decision to use $ATONE.
+
+#### Key points:
+
+- Initial update to try out $ATONE as the ticker for AtomOne.
+- Discussion on the potential issue with the $ATOM1 ticker and links to relevant conversations.
+- Suggestions to use $ATOM1 in documentation to emphasize concept explanation, with potential consideration for terms like $ATOMX as an equivalent to $phATOM1.
+- Community suggestions for different tickers including $GAIA and the historical context of $ATONE, meaning "at one" or "united and reconciled".
+- The decision to use $ATONE as a distinct identity, reflecting the spirit of AtomOne and its community.
+- Discussions on the graphic identity of AtomOne and expanding the brand theme beyond just the chemical perspective of atomic structure.
+- Various community members contributed to the discussion, suggesting different ticker names and supporting the use of $ATONE.
+- Emphasis on creating a brand identity that is cohesive with the story and ethos of AtomOne.
+
 ---
 
 ## Stakeholder Relations
@@ -301,16 +453,6 @@ who unstaked ATOM due to recent proposals.
 - Concerns about governance direction and proposals.
 - Challenges and solutions for rewarding supporters.
 - Rewarding contributors and creators within the AtomOne ecosystem.
-
-### Official Cosmos ATOM-ONE NFT
-
-[<ins>Issue #20</ins>](https://github.com/atomone-hub/genesis/issues/20) explores creating an official 
-AtomOne NFT.
-
-#### Key points:
-
-- NFT as recognition for early AtomOne project supporters.
-- Potential future benefits and use cases for the NFT.
 
 ---
 
@@ -341,6 +483,51 @@ list for AtomOne.
 - Mechanism for organization and participation.
 - Proposed method for member listing.
 - Importance of transparency and public engagement.
+
+### FAQ / AMA
+
+[<ins>Issue #55</ins>](https://github.com/atomone-hub/genesis/issues/55) establishes a forum for the AtomOne community to ask questions, which will be addressed in a new FAQ.md file and possibly discussed in AMA (Ask Me Anything) sessions.
+
+#### Key points:
+
+- Encouragement for community members to ask questions, regardless of whether they feel these questions merit their own issue.
+- Selected questions will be replied to in a new FAQ.md file, and possibly discussed during AMA sessions.
+- Reference to a related issue (#53) for additional context.
+- Specific questions raised by community members, such as how to participate in meetings and details about snapshot dates or block heights for airdrops.
+- Requests for guidance on how to engage with the project, including making pull requests and joining meetings.
+- Queries about the snapshot date or block height and discussions on airdrop-related support for centralized exchanges (CEXs) like Binance, Coinbase, Upbit, etc.
+- Direction to use specific issues, like #18 for snapshot-related questions.
+
+### Create an awesome-atomone / community repo
+
+[<ins>Issue #70</ins>](https://github.com/atomone-hub/genesis/issues/70) discusses the idea of creating a community-driven repository for AtomOne.
+
+#### Key points:
+
+- Proposal to create a repository similar to "awesome-gno" on GitHub, serving as a space for community-generated content and discussions.
+- Potential repository names suggested include 'awesome-atomone' and 'awesome-atone'.
+- The repository would include a disclaimer stating that the content is community-generated and unofficial.
+- It would provide a platform for community discussions, initiatives, recipes, and scripts.
+- Consideration of using the Wiki feature instead of PRs for maintaining news and summaries, making moderation more manageable.
+- The repository could serve as a reference for new forks, important tweets, and other relevant information.
+- Discussion on limiting AI usage to a specific section within the repository and setting boundaries for its use.
+- Support for the idea of starting with an AWESOME.md file and observing how it evolves.
+- Suggestions for maintaining a balance between AI assistance and human curation.
+
+### How to Attract Aligned Individuals to a New Constitutional Hub
+
+[<ins>Issue #72</ins>](https://github.com/atomone-hub/genesis/issues/72) discusses strategies for attracting individuals who are aligned with the ethos and principles of AtomOne to the new constitutional hub.
+
+#### Key points:
+
+- Focus on drawing in individuals both inside and outside the crypto space who align with AtomOne's vision of prioritizing security and hub minimalism.
+- Addressing societal issues that led to distrust in current institutions as a way to connect with a broader audience.
+- Proposing content creation that highlights problems created by existing systems, targeting a wider audience beyond crypto-natives.
+- Idea of creating a "political economy" within the AtomOne Hub, involving commerce of physical goods to engage the community in a new way.
+- Suggestion to scale voting power in favor of delegators, reducing the influence of validators in governance decisions to enhance the sense of equality in participation.
+- Discussions on how to make the ATOM1 Hub appealing to a wider range of people, particularly those disillusioned with traditional institutions.
+- Considerations of how to structure the ecosystem to encourage participation from non-technical members.
+- Suggestions for integrating commerce and real-world applications into the AtomOne ecosystem to foster a sense of community and participation.
 
 ---
 
@@ -402,3 +589,32 @@ for categorizing issues in AtomOne.
 - Categorization and labelling system proposals.
 - Permission is required to create projects or assign issues.
 - Suggestions for category tags and maintenance.
+
+### META - High-Level Roadmap with DAGs
+
+[<ins>Issue #50</ins>](https://github.com/atomone-hub/genesis/issues/50) discusses creating a comprehensive high-level roadmap for AtomOne using Directed Acyclic Graphs (DAGs) to structure and visualize the development process.
+
+#### Key points:
+
+- The aim to create and update high-level DAGs that can serve as indexes for navigating various topics within the project.
+- Moderators with write permissions are tasked to keep top-level DAGs updated based on community suggestions.
+- Outline of key milestones and tasks for AtomOne Phase 1 - Pre-IBC's Tasks.
+- Items include defining the constitution, legal and licensing issues, governance and community engagement strategies, technical aspects and innovation, documentation and resources, recovery and compliance, and preparation for mainnet launch.
+- Discussion on maintaining a single source of truth for the roadmap, with a suggestion to keep it in the README for better accessibility.
+- The roadmap includes links to related issues and discussions, such as governance improvements and software targets.
+- Preference for maintaining the roadmap tasks in the README for visibility and ease of access.
+- Suggestions for organizing the roadmap in a tree structure with checkboxes for better tracking and visualization.
+
+### Internationalization
+
+[<ins>Issue #60</ins>](https://github.com/atomone-hub/genesis/issues/60) addresses the need for translating AtomOne's documents into multiple languages, with a focus on human translation efforts.
+
+#### Key points:
+
+- Proposal to start translating documents into other languages once the paragraph structure and known issues are settled.
+- Storage of all translated documents in the repository, including the names of translators and the method of translation.
+- Preference for human translation over AI to preserve the choice of terms and to grow community expertise.
+- Encouragement for community members to contribute translations to naturally gauge interest and grow the decentralized localized community ecosystem.
+- Community members volunteering to translate documents into Spanish, Persian, Italian, and French, with an emphasis on collaborative efforts.
+- Suggestions for contracting human translators for languages where community volunteers are not available.
+- Discussion on the importance of human translators in conveying ideas accurately and preserving linguistic nuances.


### PR DESCRIPTION
Prior to AtomOne GovNo on Dec 14, 5pm UTC

replaces https://github.com/atomone-hub/genesis/pull/59