### PR TITLE
chore: add giunatale as default codeowner for PRs approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owner for all files in the repository, unless overridden by a specific rule below.
-* @jaekwon
+* @jaekwon @giunatale
 
 # Specific file/dir ownership
 /.github/ @moul


### PR DESCRIPTION
As mentioned in the title, adding myself as second default code-owner so I can approve and merge PRs without force-merging using admin rights, and instead following the regular review->merge process.