### PR TITLE
chore: refresh codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@
 /DECENTRALISTS.md @jaekwon
 /GOVERNANCE.md @giunatale @jaekwon
 /FORKING.md @moul @jaekwon
+/DISCORD.md @Ticojohnny
+/GovGen_Townhalls/ @Ticojohnny
+/snapshots/analysis/ @tbruyelle
 
 # i18n
 *.fr.md @moul @tbruyelle


### PR DESCRIPTION
refreshing codeowners based on latest contributions.

@moul @jaekwon we should also add the people listed as collaborators (@moul inlcuded)
otherwise the codeowners file will contain errors (unrecognized accounts)

you can see this directly on github, there is an error banner at the top of the file when opened in browser.