### PR TITLE
chore: rename to GovGen everywhere except Compendium

### DIFF
--- a/GovGen_Townhalls/Meeting1.md
+++ b/GovGen_Townhalls/Meeting1.md
@@ -1,44 +1,44 @@
-### **GovNo Townhall Meeting 1 Notes**
+### **GovGen Townhall Meeting 1 Notes**
 
 ### Date: December 14th, 2023
 
 [Link to recording](https://x.com/Allinbits_inc/status/1735383245787701589?s=20)
 
-Meeting notes from the first GovNo townhall.
+Meeting notes from the first GovGen townhall.
 
 Action: Create Discord moderation policy and setup
 
-- **Introduction: What is the [GovNo](https://github.com/atomone-hub/genesis/issues/71) chain: definition, purpose, utility**
-    - GovNo is primarily a governance chain, with the design to get a large consensus amongst the No/NWV voters on what and how AtomOne should work
-    - Purpose of GovNo is to find sentiment and get direction
-    - Why GovNo? The genesis for AtomOne and GovNo stems from prop 848, which defined a split. No/NWV voters are key, and AtomOne wouldn’t make sense if there wasn’t support from No/NWV voters on this proposal.
-    - GovNo is not governance for AtomOne, but a way to bootstrap governance to kick it off
-    - What is AiB’s part? We are a participant and contributor in GovNo having voted No on prop 848, along with many members of the community, and you are an equal in this project;we want to facilitate a way for the No/NWV vote community to speak out. We are primarily here to serve and moderate the discussion on No/NWV voters.
-    - For building GovNo, we should consider our available tooling
+- **Introduction: What is the [GovGen](https://github.com/atomone-hub/genesis/issues/71) chain: definition, purpose, utility**
+    - GovGen is primarily a governance chain, with the design to get a large consensus amongst the No/NWV voters on what and how AtomOne should work
+    - Purpose of GovGen is to find sentiment and get direction
+    - Why GovGen? The genesis for AtomOne and GovGen stems from prop 848, which defined a split. No/NWV voters are key, and AtomOne wouldn’t make sense if there wasn’t support from No/NWV voters on this proposal.
+    - GovGen is not governance for AtomOne, but a way to bootstrap governance to kick it off
+    - What is AiB’s part? We are a participant and contributor in GovGen having voted No on prop 848, along with many members of the community, and you are an equal in this project;we want to facilitate a way for the No/NWV vote community to speak out. We are primarily here to serve and moderate the discussion on No/NWV voters.
+    - For building GovGen, we should consider our available tooling
 - Audits: important, but as there is no central authority it isn’t always done, so everyone has to be cautious about the technology they are using
 - Questions, we need to answer:
 - How much support do we need from No/NWV voters? We need to find the right answers to find consensus among No/NWV voters
 - What ratio of Yes and No/NWV voters should be included in AtomOne?
 - **Define the Governance Token**
-    - **GovNo token and the governance structure:**
-        - The purpose of the GovNo chain, token and structure is to help us answer questions and coordinate together
+    - **GovGen token and the governance structure:**
+        - The purpose of the GovGen chain, token and structure is to help us answer questions and coordinate together
         - We don’t have the infrastructure to deal with per person uniqueness, so anything to modify distribution will end up creating distortions that other people will exploit. Example: Bot accounts ended up voting yes - 164,000 yes voters and 6,867 No voters.
         - NWV for purity will receive the same as No voters and those that abstained could also receive a proportionate amount..
-        - Proposal for a two step distribution: GovNo token to be distributed only to NWV and No and they can decide to increase the distribution to share with delegators who didn’t vote but inherited the vote from their validators
+        - Proposal for a two step distribution: GovGen token to be distributed only to NWV and No and they can decide to increase the distribution to share with delegators who didn’t vote but inherited the vote from their validators
         - Proposal for $ATONE distribution, abstainers and non voters to receive 50% of the rewards that No voters receive and on top of that a slight penalty for not participating that shouldn’t be significant and open to making it 0. Why? You don’t want to force people to vote.
-    - **GovNo governance vs. Cosmos Hub governance**
-    - **Who are the members of GovNo?**
+    - **GovGen governance vs. Cosmos Hub governance**
+    - **Who are the members of GovGen?**
         - No voting members and NWV voters
     - **How will the voting system work?**
         - Start simple, minimal modifications to the Cosmos governance module. Over time, we can iterate and improve it.
-        - We can create a multitude of GovNo chains, maybe throw them away, but ultimately the community will select the primary GovNo chain.
+        - We can create a multitude of GovGen chains, maybe throw them away, but ultimately the community will select the primary GovGen chain.
         - It is important to not require new tooling to use the system. However, if there is new software, it could be a vulnerability at this time since we are loosely coordinated. There is no central authority to audit the software, so we have to be cautious.
         - Suggested change: In terms of editing code, it is to increase governance duration. Let's consider infinite duration, all proposals last forever and you can change your votes or even create a duplicate because you want a new measure.
-- **GovNo and AtomOne:**
-    - **What is the relation between GovNo and AtomOne?**
-        - We fork the chain of Gaia, GovNo chain, we don’t make a lot of changes, the governance proposals on GovNo shouldn’t have much effect.
-    - **How is GovNo contributing to AtomOne?**
-- **How to contribute to GovNo:**
+- **GovGen and AtomOne:**
+    - **What is the relation between GovGen and AtomOne?**
+        - We fork the chain of Gaia, GovGen chain, we don’t make a lot of changes, the governance proposals on GovGen shouldn’t have much effect.
+    - **How is GovGen contributing to AtomOne?**
+- **How to contribute to GovGen:**
     - **Validators**
         - Should disclose relations without validators, this is required and if related should follow certain rules so there is independence among split validators.
         - If a validator and associations are too big, we find a way to cap group validators, because what we want and need is more or less equal full size validators unless we make it explicit.
@@ -56,7 +56,7 @@ Action: Create Discord moderation policy and setup
         - AtomOne is consistent with writings during Atom2, a minimal hub
         - AiB should not own it, start with No voters and grow
         - Link to all forks from atom one repo
-        - Community creating a split and using GovNo and everyone can play a role here
+        - Community creating a split and using GovGen and everyone can play a role here
     - **What is the best way for people to self organize?**
         - **Are there dedicated channels to stay in touch with the current development?**
             - Discord, and build a Discord moderation policy
@@ -67,25 +67,25 @@ Action: Create Discord moderation policy and setup
 - Create Discord channel
 - Discuss there where and when for the next townhall
 - Discord. Markdown file
-- Gabriel suggests proposals on branding and identity of AtomOne and GovNo this will affect the channels
+- Gabriel suggests proposals on branding and identity of AtomOne and GovGen this will affect the channels
 - GitHub is the place to have permanent discussion, move from Discord to GitHub. Discord is the live chat medium.
 
 **Questions and discussion from community during the townhall Q&A:**
 
-- If you have delegated and did not vote on prop 848 but your validator voted NO, should you receive GovNo tokens?
-    - GovNo is a sentiment chain
+- If you have delegated and did not vote on prop 848 but your validator voted NO, should you receive GovGen tokens?
+    - GovGen is a sentiment chain
     - Proposal is to focus on the votes without delegation
-    - Fork Gaia, create GovNo chain, don’t make a lot of changes
+    - Fork Gaia, create GovGen chain, don’t make a lot of changes
         - Primary purpose is to understand the sentiment of the community
         - Increase the threshold to 67% from 50%+1
-        - Snapshot of GovNo- limited to the NO voters at the limit of #848
-        - GovNo- the GovNo chain ideally should not be transferable to preserve the initial distribution set
-    - We should not count validator delegations, GovNo is a sentiment chain, we don’t know who to delegate to
+        - Snapshot of GovGen- limited to the NO voters at the limit of #848
+        - GovGen- the GovGen chain ideally should not be transferable to preserve the initial distribution set
+    - We should not count validator delegations, GovGen is a sentiment chain, we don’t know who to delegate to
     - How can we delegate and trust that delegation system? Because of that it’s better to focus on votes without delegation.
-    - Chain is called GovNo, GovNo is staking token, distribution to be decided
-    - Minimal changes, proposals on GovNo have little effect, not trying to change parameters or improve the chain but the primary purpose is to understand what portion of the chain believes this or that.
-    - Nothing is really decided on GovNo until there’s a higher percentages (67%) from 51 to 67 because that’s safer
-    - With GovNo we should follow the desired governance structure of AtomOne
+    - Chain is called GovGen, GovGen is staking token, distribution to be decided
+    - Minimal changes, proposals on GovGen have little effect, not trying to change parameters or improve the chain but the primary purpose is to understand what portion of the chain believes this or that.
+    - Nothing is really decided on GovGen until there’s a higher percentages (67%) from 51 to 67 because that’s safer
+    - With GovGen we should follow the desired governance structure of AtomOne
 - How do you enforce legal jurisdiction?
     - AtomOne has its own court and we can look at the evidence, for a simple court procedure.
 - How do avoid a super majority
@@ -93,10 +93,10 @@ Action: Create Discord moderation policy and setup
 - Instead of ICS chains, having their own tokens they can use base tokens of the main chain.
 - Validators voting with their own tokens, not their delegators?
     - For AtomOne is not decided
-    - Use GovNo to come to consensus
+    - Use GovGen to come to consensus
     - Approval of validators and stakers
         - Two parties?
-    - For GovNo, no value to protect so validators don’t have as much weight
+    - For GovGen, no value to protect so validators don’t have as much weight
 - What about newcomers?
     - Some of us want after launching AtomOne that they are out of luck
     - It makes more sense to demonstrate a split in a friendly and constructive way, if we slash them out, we’re incentivizing the narrative that we overtly competing
@@ -112,25 +112,25 @@ Action: Create Discord moderation policy and setup
             - Phantom convert to Photons?
             - Photon holders will get diluted “when gaia fails”
             - Can they merge? Can they work together?
-            - Better idea of what people are comfortable with after GovNo launches
-- Should we limit transfers of GovNo tokens?
-    - For GovNo, absolutely. Use them, delegate/stake and vote but cannot send
-- Is the snapshot for GovNo tokens done by 848 closing vote?
-    - Yes for the purpose of GovNo, which is sentiment understanding for the purpose of AtomOne, so limit only to No voters.
+            - Better idea of what people are comfortable with after GovGen launches
+- Should we limit transfers of GovGen tokens?
+    - For GovGen, absolutely. Use them, delegate/stake and vote but cannot send
+- Is the snapshot for GovGen tokens done by 848 closing vote?
+    - Yes for the purpose of GovGen, which is sentiment understanding for the purpose of AtomOne, so limit only to No voters.
     - Question: validator delegation included?
     - Question: Changes occurring to the state impact?
         - No only the snapshot
 - Consider using DAODAO?
 - Would be good to rely on what we have, going with general idea of not introducing too many things
-- GovNo can start creating validator base community for AtomOne
+- GovGen can start creating validator base community for AtomOne
 - Makes sense to eat our own dog food that way we have a base for validator community
 - Full functionality from app and web browser?
     - Yes
-- Potentially try both, DAODAO as a temporary solution to get direction for GovNo
-- Purpose of GovNo is to find sentiment?
+- Potentially try both, DAODAO as a temporary solution to get direction for GovGen
+- Purpose of GovGen is to find sentiment?
     - Yes, to get direction
 - Will people be excluded for not voting?
-    - No voters need to support GovNo decisions and will probably agree that we should include non voters
+    - No voters need to support GovGen decisions and will probably agree that we should include non voters
     - Even yes voters should be included
     - 7th comment in issue 12 on repo
     - Start with same distribution of 848
@@ -139,13 +139,13 @@ Action: Create Discord moderation policy and setup
         - If you voted yes, 1:1
         - If you abstain or no vote is 1.5x
 - When we talked about no voters are no and NWV voters different?
-- For GovNo we shouldn’t, it’s a question because we don’t know. Keep it simple for NWV
+- For GovGen we shouldn’t, it’s a question because we don’t know. Keep it simple for NWV
 - Was this a veto worthy proposal?
     - Yes from perspective of security
     - Are we gonna punish most of us?
 - How do we consider punishing of non voters
     - Counterproductive to not punish because you should DYOR on validators
-    - Member for punishing non voters, “if we include lazy voters they stay lazy” for GovNo
+    - Member for punishing non voters, “if we include lazy voters they stay lazy” for GovGen
 - Do we have a timeline for when we expect AtomOne?
     - January Q1
     - Being scrappy is better
@@ -165,5 +165,5 @@ Action: Create Discord moderation policy and setup
     - KYC for validators?
         - Genesis validators of AtomOne, maybe makes sense to KYC the validators
         - After launch - up to the stakers of the chain to decide
-        - Not for GovNo
+        - Not for GovGen
         - Issue 75: https://github.com/atomone-hub/genesis/issues/75

--- a/GovGen_Townhalls/Meeting2.md
+++ b/GovGen_Townhalls/Meeting2.md
@@ -1,4 +1,4 @@
-### **GovNo Townhall Meeting 2 Notes**
+### **GovGen Townhall Meeting 2 Notes**
 
 ### Date: February 9th, 2024
 
@@ -105,7 +105,7 @@ Part of the conversation focused on onboarding validators, discussing criteria, 
 
   - Community town halls and get togethers:  (5 minutes)
 
-    - Structure of town halls, alternating between engineering and community calls.Tentative agendas to be published on GitHub at <https://github.com/atomone-hub/genesis/tree/main/GovNo_Townhalls> 2-3 days in advance of the each call - make sure you make suggestions for topics that you would like to discuss
+    - Structure of town halls, alternating between engineering and community calls.Tentative agendas to be published on GitHub at <https://github.com/atomone-hub/genesis/tree/main/GovGen_Townhalls> 2-3 days in advance of the each call - make sure you make suggestions for topics that you would like to discuss
 
     - Meeting notes and recordings will be published after each community call on GitHub 
 
@@ -129,7 +129,7 @@ Part of the conversation focused on onboarding validators, discussing criteria, 
 
 - Branding, naming and visuals (10 minutes)
 
-  - Discuss the name change - [proposing](https://github.com/atomone-hub/genesis/pull/108) GovNo becomes GovGen due to community feedback
+  - Discuss the name change - [proposing](https://github.com/atomone-hub/genesis/pull/108) GovGen becomes GovGen due to community feedback
 
   - @wnmnsr would you want to come to the townhall to discuss AtomOne branding ideas?
 

--- a/GovGen_Townhalls/Meeting3.md
+++ b/GovGen_Townhalls/Meeting3.md
@@ -1,4 +1,4 @@
-### **GovNo Townhall Meeting 3 Notes**
+### **GovGen Townhall Meeting 3 Notes**
 
 ### Date: February 13th, 2024
 


### PR DESCRIPTION
As specified in the title, complete the renaming GovNo->GovGen and cleanup.

@salmad3 I am leaving the update of the compendium to you.